### PR TITLE
Expand roadmap with intelligence features and telemetry capture

### DIFF
--- a/ENHANCEMENTS.md
+++ b/ENHANCEMENTS.md
@@ -23,3 +23,16 @@
 - **Automate calculations** with unit tests that cover detection/recovery totals, nested table shaping, and dashboard aggregations. Pair this with Playwright/Cypress smoke tests to ensure DOCX generation remains stable across refactors.
 - **Add diagnostics and logging hooks** (structured console logs, downloadable debug reports) so audit teams can share reproducible traces when generation fails.
 - **Wire up continuous integration** to lint, type-check, run tests, and build the distributable artifact on every change, guaranteeing that the packaged single-page app is always in sync with source modules.
+
+## 6. Intelligence, Collaboration, and Automation
+- **Embed contextual AI assistance** that can summarise drafted paras, propose remediation actions, or flag inconsistencies between risk statements and quantitative data. Running prompts against a secure, self-hosted LLM (or an API gateway that redacts sensitive content) would give analysts smarter starting points without leaking regulated information.
+- **Layer in scenario modelling** that lets reviewers explore “what-if” adjustments to detection, recovery, and revenue forecasts. A reactive calculation engine paired with charting (e.g., Observable Plot embedded offline) can highlight downstream impacts of remedial actions.
+- **Introduce collaborative review workflows**: allow analysts to request approvals, assign follow-up tasks, and track status within the tool. Lightweight real-time sync via WebRTC data channels or a hosted SignalR/Pusher service would let geographically distributed teams iterate together without emailing JSON files back and forth.
+- **Automate downstream publishing** by integrating with document management systems (e.g., SharePoint, Alfresco). A secured connector could push final DOCX exports and metadata (finding owner, severity, completion date) directly into retention repositories.
+
+## 7. Backend Data Capture and Telemetry Strategy
+- **Session event streaming**: instrument the UI to emit structured events (field edits, para additions, generation attempts) to a telemetry pipeline. A background `navigator.sendBeacon` or `fetch` to a hardened ingestion endpoint (Cloudflare Workers, Azure Function) can persist audit-friendly timelines without slowing the UI.
+- **Form-state snapshots**: provide an opt-in sync that periodically serialises the DAR payload and posts it to a backend document store (Cosmos DB, DynamoDB, PostgreSQL JSONB). Pair the uploads with encryption-at-rest and per-tenant keys so sensitive fraud data remains compliant.
+- **Metrics aggregation**: process captured events through a stream processor (Kafka Streams, Kinesis Analytics) to derive KPIs—average completion time, common validation failures, risk categorisation trends—and expose them via a secure analytics dashboard for programme leadership.
+- **Template/version analytics**: log which DOCX templates and remediation playbooks are used during generation. This enables A/B comparisons of template efficacy and early detection of outdated guidance.
+- **Compliance and retention controls**: add backend policies that honour data retention schedules, redact personally identifiable information before long-term storage, and surface access logs for audits. Provide administrators with tooling to export or purge captured sessions on demand.


### PR DESCRIPTION
## Summary
- add an intelligence and collaboration roadmap for AI guidance, scenario modelling, workflows, and downstream integrations
- outline backend data capture options including telemetry streaming, secure storage, analytics, and compliance controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ee1ece68832c990ec86c06f84f15