### PR TITLE
Add task plans for pending enhancements

### DIFF
--- a/tasks/architecture-and-build-system.md
+++ b/tasks/architecture-and-build-system.md
@@ -1,0 +1,21 @@
+# Architecture and Build System Enhancements
+
+## Objectives
+- Modularise the front-end codebase into dedicated HTML, CSS, and JavaScript source files managed through a modern build pipeline.
+- Bundle third-party dependencies locally to eliminate CDN reliance and enable integrity checks.
+- Introduce a reusable component abstraction to simplify repeated UI patterns and state management.
+
+## Tasks
+- [ ] Audit current inline HTML, CSS, and JavaScript within `index.html` and document required separations.
+- [ ] Select and configure a bundler (e.g., Vite or Parcel) that supports ES modules or TypeScript while outputting a single distributable HTML bundle.
+- [ ] Extract styles into standalone `.css` files and scripts into `.js`/`.ts` modules organised by feature area.
+- [ ] Update build tooling to generate the existing single-file deliverable, ensuring paths and asset loading remain compatible with offline use.
+- [ ] Install JSZip, FileSaver, and any other third-party packages locally and configure the bundler to include them in the build output with hash-based integrity metadata.
+- [ ] Design and implement a lightweight component model (custom elements, Lit, or equivalent) for repeated UI sections such as para cards and revenue tables.
+- [ ] Refactor existing DOM-manipulation logic to leverage the component abstraction, ensuring stateful features remain functional.
+- [ ] Document new project structure, development workflow, and build commands in `README.md`.
+
+## Acceptance Criteria
+- Development workflow uses the selected build tool and produces an optimised single-page bundle.
+- All third-party libraries load from local bundles with integrity guarantees.
+- Core UI blocks reuse the new component abstraction without regressions in functionality.

--- a/tasks/backend-data-capture-and-telemetry.md
+++ b/tasks/backend-data-capture-and-telemetry.md
@@ -1,0 +1,21 @@
+# Backend Data Capture and Telemetry Enhancements
+
+## Objectives
+- Capture structured session activity for telemetry and compliance purposes.
+- Provide secure backend storage and analytics for form-state snapshots and metrics.
+- Enforce data retention, privacy, and access control policies.
+
+## Tasks
+- [ ] Design an event schema for UI interactions (field edits, para additions, generation attempts) and instrument the front end to emit events.
+- [ ] Implement background delivery of events via `navigator.sendBeacon` or resilient `fetch` calls to a hardened ingestion endpoint.
+- [ ] Build a backend ingestion service (e.g., Cloudflare Workers, Azure Function) that validates, stores, and secures incoming events.
+- [ ] Offer opt-in form-state snapshot syncing to a compliant document store (Cosmos DB, DynamoDB, PostgreSQL JSONB) with encryption-at-rest.
+- [ ] Develop analytics pipelines (Kafka Streams, Kinesis Analytics, etc.) that derive KPIs from captured events.
+- [ ] Create dashboards exposing metrics such as completion time, validation failures, and risk trends to authorised stakeholders.
+- [ ] Log template usage and remediation playbook selections for version tracking and A/B testing.
+- [ ] Implement retention, redaction, export, and purge capabilities aligned with compliance policies.
+
+## Acceptance Criteria
+- Telemetry events are captured reliably without degrading user experience.
+- Backend storage and analytics pipelines operate securely with role-based access controls.
+- Administrators can manage data retention and access logs in accordance with regulations.

--- a/tasks/data-integrity-and-security.md
+++ b/tasks/data-integrity-and-security.md
@@ -1,0 +1,20 @@
+# Data Integrity and Security Enhancements
+
+## Objectives
+- Prevent malicious or malformed content from being restored into the application state.
+- Enforce strong validation for all persisted and user-entered data with actionable feedback.
+- Modernise clipboard interactions to rely on secure, standards-based APIs.
+
+## Tasks
+- [ ] Integrate a trusted sanitisation library (e.g., DOMPurify) and run imported JSON or restored sessions through it before rendering.
+- [ ] Define a strict data schema covering gist editors, verification text, numeric inputs, and dates.
+- [ ] Adopt a validation library such as Zod or Yup to validate the schema on load, before save, and prior to DOCX generation.
+- [ ] Implement user-facing error messages that clearly identify invalid fields and suggest corrections.
+- [ ] Replace `document.execCommand` usage with the asynchronous Clipboard API for copy and paste flows.
+- [ ] Provide paste handlers that normalise tables and preserve formatting while blocking unsafe markup.
+- [ ] Add automated tests (unit or integration) covering sanitisation and schema validation edge cases.
+
+## Acceptance Criteria
+- Application rejects and reports invalid or unsafe session payloads without rendering arbitrary markup.
+- All clipboard operations use the modern asynchronous API and maintain formatting fidelity.
+- Validation errors are surfaced clearly to the user and prevent progression to DOCX generation until resolved.

--- a/tasks/document-templating-and-extensibility.md
+++ b/tasks/document-templating-and-extensibility.md
@@ -1,0 +1,20 @@
+# Document Templating and Extensibility Enhancements
+
+## Objectives
+- Decouple DOCX templates from the application bundle and support managed template updates.
+- Create reusable WordprocessingML mapping utilities with clear documentation.
+- Prepare the system for multiple template variants and safer template maintenance.
+
+## Tasks
+- [ ] Externalise the DOCX template into configurable assets that can be uploaded or selected at runtime.
+- [ ] Build a template manager interface with metadata tracking (version, checksum, page settings, locale).
+- [ ] Implement secure storage and loading mechanisms for template files, including validation of file integrity.
+- [ ] Refactor the WordprocessingML merge logic into documented utility modules with unit tests.
+- [ ] Map each form field to its target XML node and record the mapping in developer documentation.
+- [ ] Support switching between templates and ensure DOCX generation honours the selected version.
+- [ ] Provide migration guidance for administrators when new templates are introduced.
+
+## Acceptance Criteria
+- Templates can be managed without editing embedded Base64 strings in the codebase.
+- Mapping utilities are tested, documented, and reusable across template versions.
+- DOCX generation functions correctly with multiple template options.

--- a/tasks/intelligence-collaboration-and-automation.md
+++ b/tasks/intelligence-collaboration-and-automation.md
@@ -1,0 +1,22 @@
+# Intelligence, Collaboration, and Automation Enhancements
+
+## Objectives
+- Provide contextual AI assistance to support drafting and validation activities.
+- Enable scenario modelling for forecasting and remediation planning.
+- Introduce collaborative workflows and downstream publishing capabilities.
+
+## Tasks
+- [ ] Evaluate secure LLM deployment options (self-hosted or API gateway) that satisfy regulatory constraints.
+- [ ] Design prompt workflows for summarising paras, suggesting remediation, and detecting inconsistencies.
+- [ ] Integrate AI assistance into the UI with clear user controls and audit logs of generated content.
+- [ ] Build a scenario-modelling engine capable of adjusting detection, recovery, and revenue forecasts reactively.
+- [ ] Embed data visualisations (e.g., charts) that illustrate impacts of “what-if” adjustments.
+- [ ] Implement collaborative features for task assignment, approval requests, and status tracking.
+- [ ] Choose and integrate a real-time sync mechanism (WebRTC, SignalR, Pusher, etc.) for multi-user editing.
+- [ ] Develop connectors to document management systems (SharePoint, Alfresco) for automated publishing of outputs.
+- [ ] Ensure all new features include security, privacy, and compliance safeguards with appropriate documentation.
+
+## Acceptance Criteria
+- AI assistance operates within compliance boundaries and supports analysts without leaking sensitive data.
+- Scenario modelling tools provide actionable insights and update the UI responsively.
+- Collaborative workflows and publishing integrations streamline multi-analyst review processes.

--- a/tasks/quality-assurance-and-tooling.md
+++ b/tasks/quality-assurance-and-tooling.md
@@ -1,0 +1,20 @@
+# Quality Assurance and Tooling Enhancements
+
+## Objectives
+- Establish automated testing coverage for critical calculations and workflows.
+- Provide diagnostics that help reproduce and debug failures in the field.
+- Ensure continuous integration enforces build quality and distributable integrity.
+
+## Tasks
+- [ ] Identify core calculation paths (detection/recovery totals, nested tables, dashboard aggregations) and design unit tests for each.
+- [ ] Create integration or end-to-end tests (Playwright/Cypress) that exercise DOCX generation and key UI flows.
+- [ ] Configure testing frameworks within the chosen build system and document how to run the suites.
+- [ ] Implement structured logging within the app, capturing key events and error states.
+- [ ] Provide a mechanism to download diagnostics or debug reports for support teams.
+- [ ] Set up a CI pipeline that runs linting, type-checking, tests, and build steps on every change.
+- [ ] Publish build artifacts from CI for verification and distribution.
+
+## Acceptance Criteria
+- Automated tests cover mission-critical calculations and pass reliably.
+- Diagnostic information is easily retrievable when failures occur.
+- CI pipelines gate merges on linting, testing, and build success.

--- a/tasks/user-experience-and-accessibility.md
+++ b/tasks/user-experience-and-accessibility.md
@@ -1,0 +1,21 @@
+# User Experience and Accessibility Enhancements
+
+## Objectives
+- Provide clear, accessible validation feedback and guidance throughout the workflow.
+- Simplify navigation of large forms with progressive disclosure and progress tracking.
+- Ensure all interactive controls meet keyboard and screen-reader accessibility requirements.
+
+## Tasks
+- [ ] Identify required fields and add semantic indicators (labels, aria attributes, text descriptions) for validation states.
+- [ ] Implement an error summary region that aggregates validation issues and links to affected fields.
+- [ ] Introduce collapsible or accordion sections for large form groups to reduce cognitive load.
+- [ ] Add a progress indicator and pre-flight checklist that blocks export until critical data is complete.
+- [ ] Enhance autosave insights or dashboards to highlight missing revenue or remediation data.
+- [ ] Audit para reordering, risk-table editing, and notification flows for keyboard operability.
+- [ ] Add aria-live regions and focus management for toast notifications and dynamic updates.
+- [ ] Conduct accessibility testing (manual and automated) to ensure WCAG compliance targets are met.
+
+## Acceptance Criteria
+- Users receive accessible, text-based validation cues in addition to colour changes.
+- Form navigation is streamlined with collapsible sections and progress tracking.
+- Keyboard-only and screen-reader users can complete all workflows without barriers.


### PR DESCRIPTION
## Summary
- add structured task plans for each enhancement theme in ENHANCEMENTS.md
- outline objectives, detailed task lists, and acceptance criteria for architecture, security, UX, templating, quality, intelligence, and telemetry tracks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8f4467728832ca4299c8a9c76ed28