### PR TITLE
Require Part-I inputs while keeping Generate button available

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,18 @@ DAR_TOOL is a single-page web application that helps CGST audit teams prepare Dr
 - **Risk flag tracker** – Provides an editable table for Template Table 3 so auditors can log risk parameters, descriptions, and verification notes. 【F:index.html†L360-L379】【F:index.html†L2920-L2934】
 - **Issuing authority block** – Captures issuing officer information and injects a formatted signature table into the generated report. 【F:index.html†L384-L417】【F:index.html†L2885-L2915】
 - **Real-time dashboard and totals ribbon** – Surfaces aggregate detection/recovery totals and missing-data warnings to highlight gaps before generation. 【F:index.html†L180-L197】【F:index.html†L423-L456】【F:index.html†L2938-L2944】
+- **Accessible pre-flight checklist** – Tracks readiness for key Part-I fields, visit dates, and para gists, announces progress for assistive tech, and flags paras missing revenue so autosave notices stay informative without blocking the Generate button. 【F:index.html†L187-L230】【F:index.html†L528-L556】【F:index.html†L706-L771】【F:index.html†L2333-L2354】
 - **Session management and autosave** – Supports manual JSON export/import of work in progress and automatically snapshots sessions to localStorage with a restorable history view. 【F:index.html†L467-L480】【F:index.html†L2013-L2240】【F:index.html†L2990-L3055】
 - **One-click DOCX generation** – Uses embedded JSZip and FileSaver libraries to merge the captured data into the bundled Word template, remove document protections, and trigger a download of the completed DAR. 【F:index.html†L162-L163】【F:index.html†L2613-L2915】【F:index.html†L2937-L2977】
 
 ## Getting started
 1. **Open the application** – Launch `index.html` in a modern Chromium- or Firefox-based browser. Network access is required on first load so the JSZip and FileSaver CDNs can provide the generation libraries. 【F:index.html†L162-L177】
-2. **Fill Part-I details** – Complete the entity information, add one or more visit dates, and document the audit circle, group, and team members. 【F:index.html†L208-L299】
+2. **Fill Part-I details** – Complete every Part-I field (A.R. No. is optional), add one or more visit dates, and document the audit circle, group, and team members. 【F:index.html†L208-L299】
 3. **Enter detection and recovery figures** – Input cash/ITC amounts; totals are recalculated automatically and mapped into the nested tables of the Word template. 【F:index.html†L302-L337】【F:index.html†L2460-L2706】
 4. **Capture summary paras** – Use the “Add Para” buttons to create major or minor entries, draft gists and audit comments, and record agreement/revenue outcomes. 【F:index.html†L340-L357】【F:index.html†L2013-L2089】
 5. **Log risk flags** – Populate Template Table 3 rows with risk parameters, descriptions, and verification notes using the editor embedded in the Verification column. 【F:index.html†L360-L379】【F:index.html†L2920-L2934】
 6. **Review dashboards** – Check the totals ribbon and dashboard for outstanding data gaps; warnings appear if revenue details are missing from any para. 【F:index.html†L180-L197】【F:index.html†L423-L456】【F:index.html†L2938-L2944】
-7. **Generate the DAR** – Click **Generate DAR** to merge your inputs into the embedded Word template; the tool strips editing protections and downloads `Target-Filled.docx`. You can also re-download the last output without regenerating. 【F:index.html†L2937-L2977】
+7. **Generate the DAR** – Review the pre-flight checklist (the Generate button remains active), then click **Generate DAR** to merge your inputs into the embedded Word template; the tool strips editing protections and downloads `Target-Filled.docx`. You can also re-download the last output without regenerating. 【F:index.html†L187-L230】【F:index.html†L2937-L2977】
 8. **Save or restore a session** – Export your progress as `dar-session.json`, import a saved session, or restore from the rolling autosave history if the browser supports localStorage. 【F:index.html†L467-L480】【F:index.html†L2013-L2240】【F:index.html†L2990-L3055】
 
 ## Implementation notes
@@ -30,5 +31,5 @@ DAR_TOOL is a single-page web application that helps CGST audit teams prepare Dr
 
 ## Suggested enhancements
 - **Bundle offline dependencies** – Ship JSZip and FileSaver with the project (or provide a service worker cache) so the generator works without CDN access, which is useful on restricted government networks. 【F:index.html†L162-L163】
-- **Pre-flight validation wizard** – Introduce a checklist or modal that highlights missing Part-I fields, para revenue gaps, or risk rows before allowing generation, complementing the existing dashboard warnings. 【F:index.html†L2938-L2944】
 - **Template management** – Add UI controls to upload a revised Word template or select among multiple templates so future format updates do not require editing the embedded Base64 payload manually. 【F:index.html†L2613-L2915】
+- **Collaborative review hooks** – Add lightweight task assignments or reviewer hand-offs so multiple officers can coordinate without emailing JSON session files. 【F:index.html†L2990-L3055】

--- a/index.html
+++ b/index.html
@@ -29,6 +29,25 @@
     .validation-summary h2 { margin: 0 0 8px; font-size: 18px; }
     .validation-summary ul { margin: 0; padding-left: 20px; }
     .validation-summary li { margin-bottom: 6px; }
+    .required-indicator { color: #b91c1c; font-size: 11px; font-weight: 600; margin-left: 6px; letter-spacing: 0.05em; text-transform: uppercase; }
+    .preflight-card { border: 1px solid #e2e8f0; border-radius: 12px; padding: 16px; margin-bottom: 16px; background: #f8fafc; box-shadow: 0 1px 2px rgba(15,23,42,0.05); }
+    .preflight-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 10px; }
+    .preflight-header h2 { margin: 0; font-size: 18px; color: #111827; }
+    .preflight-status { font-size: 13px; font-weight: 600; color: #1d4ed8; }
+    .preflight-status[data-state="ready"] { color: #047857; }
+    .preflight-status[data-state="blocked"] { color: #b91c1c; }
+    .preflight-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+    .preflight-item { display: flex; gap: 12px; border: 1px solid #e5e7eb; border-radius: 10px; padding: 12px; background: #fff; align-items: flex-start; }
+    .preflight-item .state-icon { width: 20px; height: 20px; border-radius: 999px; display: inline-flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 700; }
+    .preflight-item[data-state="complete"] { border-color: #bbf7d0; background: #f0fdf4; }
+    .preflight-item[data-state="complete"] .state-icon { background: #15803d; color: #fff; }
+    .preflight-item[data-state="attention"] { border-color: #fef3c7; background: #fffbeb; }
+    .preflight-item[data-state="attention"] .state-icon { background: #f59e0b; color: #fff; }
+    .preflight-item[data-state="pending"] { border-color: #fecdd3; background: #fff1f2; }
+    .preflight-item[data-state="pending"] .state-icon { background: #e11d48; color: #fff; }
+    .preflight-text { display: flex; flex-direction: column; gap: 2px; }
+    .preflight-title { font-weight: 600; color: #111827; }
+    .preflight-hint { font-size: 13px; color: #4b5563; }
     #auditDates.field-error, .paras-cards.field-error { box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.35); border-radius: 10px; }
     .rev-bars { display: grid; grid-template-columns: 1fr 1fr; gap: 6px 10px; margin-top: 6px; align-items: center; }
     .rev-bars .bar-row { display: contents; }
@@ -170,7 +189,7 @@
 <body>
   <h1>
     DAR Generator for CGST Audit Thane
-    <div class="muted" style="font-size:14px">(Fill all fields to generate DAR)</div>
+    <div class="muted" style="font-size:14px">(Fill all Part-I fields; A.R. No. is optional)</div>
   </h1>
 
   <nav class="sticky-nav" aria-label="Section navigation">
@@ -186,6 +205,51 @@
     <h2>Review required fields</h2>
     <p class="muted" style="color:#7f1d1d; margin-bottom:8px">Resolve the issues below before generating the DAR.</p>
     <ul id="validationList"></ul>
+  </section>
+
+  <section class="preflight-card" id="preflightChecklist" aria-labelledby="preflightHeading">
+    <div class="preflight-header">
+      <h2 id="preflightHeading">Pre-flight checklist</h2>
+      <span id="preflightStatus" class="preflight-status" role="status" aria-live="polite" data-state="blocked">Core details incomplete</span>
+    </div>
+    <p class="muted" style="margin-bottom:12px">Complete each item below before generating the DAR.</p>
+    <ul class="preflight-list" id="preflightList">
+      <li id="preflight-item-unit" class="preflight-item" data-state="pending">
+        <span class="state-icon" aria-hidden="true">!</span>
+        <div class="preflight-text">
+          <span class="preflight-title">Part-I details</span>
+          <span class="preflight-hint" data-default="Fill every Part-I field except the optional A.R. number.">Fill every Part-I field except the optional A.R. number.</span>
+        </div>
+      </li>
+      <li id="preflight-item-audit" class="preflight-item" data-state="pending">
+        <span class="state-icon" aria-hidden="true">!</span>
+        <div class="preflight-text">
+          <span class="preflight-title">Audit visit dates</span>
+          <span class="preflight-hint" data-default="Add at least one audit visit date using the picker above.">Add at least one audit visit date using the picker above.</span>
+        </div>
+      </li>
+      <li id="preflight-item-paras" class="preflight-item" data-state="pending">
+        <span class="state-icon" aria-hidden="true">!</span>
+        <div class="preflight-text">
+          <span class="preflight-title">Paras captured</span>
+          <span class="preflight-hint" data-default="Create at least one major or minor para before generating.">Create at least one major or minor para before generating.</span>
+        </div>
+      </li>
+      <li id="preflight-item-gist" class="preflight-item" data-state="pending">
+        <span class="state-icon" aria-hidden="true">!</span>
+        <div class="preflight-text">
+          <span class="preflight-title">Gist summaries</span>
+          <span class="preflight-hint" data-default="Summaries, agreement, and audit remarks must be filled for each para.">Summaries, agreement, and audit remarks must be filled for each para.</span>
+        </div>
+      </li>
+      <li id="preflight-item-revenue" class="preflight-item" data-state="attention">
+        <span class="state-icon" aria-hidden="true">!</span>
+        <div class="preflight-text">
+          <span class="preflight-title">Revenue data review</span>
+          <span class="preflight-hint" data-default="Enter detection and recovery figures so autosave snapshots highlight totals accurately.">Enter detection and recovery figures so autosave snapshots highlight totals accurately.</span>
+        </div>
+      </li>
+    </ul>
   </section>
 
   <div id="totalsRibbon" class="totals-ribbon" role="status" aria-live="polite">
@@ -219,22 +283,22 @@
   <div class="card" id="section-part1">
     <h3>PART-I</h3>
     <div class="grid">
-      <div><label>Name of Unit</label><input id="f_name" type="text" /></div>
-      <div><label>Registration No. (GST, ECC, STC)</label><input id="f_gstin" type="text" /></div>
-      <div><label>Commissionerate/Division/Range</label><input id="f_division" type="text" /></div>
-      <div><label>Category</label><input id="f_category" type="text" /></div>
-      <div><label>Type</label>
-        <select id="f_type">
+      <div><label>Name of Unit <span class="required-indicator">Required</span></label><input id="f_name" type="text" required aria-required="true" /></div>
+      <div><label>Registration No. (GST, ECC, STC) <span class="required-indicator">Required</span></label><input id="f_gstin" type="text" required aria-required="true" /></div>
+      <div><label>Commissionerate/Division/Range <span class="required-indicator">Required</span></label><input id="f_division" type="text" required aria-required="true" /></div>
+      <div><label>Category <span class="required-indicator">Required</span></label><input id="f_category" type="text" required aria-required="true" /></div>
+      <div><label>Type <span class="required-indicator">Required</span></label>
+        <select id="f_type" required aria-required="true">
           <option value="Small">Small</option>
           <option value="Medium">Medium</option>
           <option value="Large">Large</option>
         </select>
       </div>
-      <div><label>Goods/Services supplied</label><input id="f_product" type="text" /></div>
-      <div><label>Tariff Item (Fill HSN/SAC here)</label><input id="f_tariff" type="text" /></div>
-      <div><label>Period Covered</label><input id="f_period" type="text" /></div>
+      <div><label>Goods/Services supplied <span class="required-indicator">Required</span></label><input id="f_product" type="text" required aria-required="true" /></div>
+      <div><label>Tariff Item (Fill HSN/SAC here) <span class="required-indicator">Required</span></label><input id="f_tariff" type="text" required aria-required="true" /></div>
+      <div><label>Period Covered <span class="required-indicator">Required</span></label><input id="f_period" type="text" required aria-required="true" /></div>
       <div>
-        <label>Date of Visit</label>
+        <label>Date of Visit <span class="required-indicator">Required</span></label>
         <div id="auditDates" class="date-multi">
           <div class="row" style="gap:6px">
             <input id="f_audit_date_input" type="date" />
@@ -246,19 +310,19 @@
         </div>
       </div>
       <div><label>A.R. No.</label><input id="f_ar" type="text" /></div>
-      <div><label>MCM Date</label><input id="f_mcm" type="date" /></div>
+      <div><label>MCM Date <span class="required-indicator">Required</span></label><input id="f_mcm" type="date" required aria-required="true" /></div>
       <!-- Rows 15 and 16 are captured in dedicated nested tables below -->
     </div>
     <div style="margin-top:12px">
-      <label>Address</label>
-      <textarea id="f_address"></textarea>
+      <label>Address <span class="required-indicator">Required</span></label>
+      <textarea id="f_address" required aria-required="true"></textarea>
     </div>
     <div style="margin-top:12px">
-      <label for="f_officers">Circle, Group and Officers</label>
+      <label for="f_officers">Circle, Group and Officers <span class="required-indicator">Required</span></label>
       <div class="circle-group-row">
         <div class="circle-field">
-          <label for="f_circle" class="sub-label">Circle</label>
-          <select id="f_circle">
+          <label for="f_circle" class="sub-label">Circle <span class="required-indicator">Required</span></label>
+          <select id="f_circle" required aria-required="true">
             <option value="">Select Circle</option>
             <option value="I">I</option>
             <option value="II">II</option>
@@ -273,8 +337,8 @@
           </select>
         </div>
         <div class="circle-field">
-          <label for="f_group" class="sub-label">Group</label>
-          <select id="f_group">
+          <label for="f_group" class="sub-label">Group <span class="required-indicator">Required</span></label>
+          <select id="f_group" required aria-required="true">
             <option value="">Select Group</option>
             <option value="1">1</option>
             <option value="2">2</option>
@@ -306,7 +370,7 @@
           </select>
         </div>
       </div>
-      <textarea id="f_officers" placeholder="List officers / team members"></textarea>
+      <textarea id="f_officers" placeholder="List officers / team members" required aria-required="true"></textarea>
     </div>
   </div>
 
@@ -496,7 +560,7 @@
       <div id="overlayMessage" class="overlay-message">Working…</div>
     </div>
   </div>
-  <div id="toastContainer" class="toast-container"></div>
+  <div id="toastContainer" class="toast-container" role="region" aria-live="polite" aria-atomic="false" aria-label="Notifications"></div>
 
   <script>
     const WNS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -504,10 +568,33 @@
     const log = (...a) => { const s=a.join(' '); console.log(s); $('log').textContent += s+'\n'; };
     const setStatus = s => $('status').textContent = s;
 
+    const REQUIRED_FIELDS = [
+      { id: 'f_name', label: 'Name of Unit' },
+      { id: 'f_gstin', label: 'Registration Number' },
+      { id: 'f_division', label: 'Commissionerate/Division/Range' },
+      { id: 'f_category', label: 'Category' },
+      { id: 'f_type', label: 'Type' },
+      { id: 'f_product', label: 'Goods/Services supplied' },
+      { id: 'f_tariff', label: 'Tariff Item' },
+      { id: 'f_period', label: 'Period Covered' },
+      { id: 'f_mcm', label: 'MCM Date' },
+      { id: 'f_address', label: 'Address' },
+      { id: 'f_circle', label: 'Circle' },
+      { id: 'f_group', label: 'Group' },
+      { id: 'f_officers', label: 'Circle, Group and Officers' }
+    ];
+    const PRECHECK_BLOCKERS = ['unit', 'audit', 'paras', 'gist'];
+    const PREFLIGHT_LABELS = {
+      unit: 'Part-I details',
+      audit: 'Audit visit dates',
+      paras: 'Paras captured',
+      gist: 'Gist summaries',
+      revenue: 'Revenue data review'
+    };
+    let preflightSnapshot = { blockers: PRECHECK_BLOCKERS.length, revenueMissing: 0, gistMissing: 0, cardCount: 0 };
+
     const genBtn = $('generate');
     const downloadLastBtn = $('downloadLast');
-    // Preloaded template, enable immediately
-    genBtn.disabled = false;
     if(downloadLastBtn) downloadLastBtn.disabled = true;
     // Attach numeric/NQ restrictions and auto-calc listeners immediately
     try{ wireNestedAutoCalc(); recalcRevenue(); recalcVoluntary(); wireAuditDates(); wireParaGroupToggles(); applyGroupVisibility(); updatePart1TotalsFromParas(); }catch(e){}
@@ -720,18 +807,138 @@
       summary.setAttribute('aria-hidden','false');
     }
 
+    function setPreflightItemState(key, state, detail){
+      const item = document.getElementById(`preflight-item-${key}`);
+      if(!item) return;
+      item.dataset.state = state;
+      const icon = item.querySelector('.state-icon');
+      if(icon){
+        icon.textContent = state === 'complete' ? '✓' : state === 'attention' ? '⚠' : '!';
+      }
+      const hint = item.querySelector('.preflight-hint');
+      if(hint){
+        const base = hint.dataset.default || hint.textContent;
+        hint.textContent = detail || base;
+      }
+    }
+
+    function cardHasGistContent(card){
+      if(!card) return false;
+      const gistEl = card.querySelector('[data-role="gist"]');
+      if(!gistEl) return false;
+      const sanitizedHtml = getSanitizedHtml(gistEl);
+      const text = sanitizedHtml.replace(/<[^>]*>/g,'').trim();
+      return text.length > 0;
+    }
+
+    function cardHasRevenueContent(card){
+      if(!card) return false;
+      const hasValue = (val)=>{
+        if(val == null) return false;
+        const str = String(val).trim();
+        if(!str) return false;
+        if(/^[Nn][Qq]$/.test(str)) return true;
+        return parseAmount(str) !== null;
+      };
+      if(card.dataset.revMode === 'major'){
+        const data = readMajorRevenue(card) || majorRevenueDefaults();
+        const cats = ['tax','interest','penalty','late'];
+        for(const cat of cats){
+          const node = data.detection?.[cat];
+          if(!node) continue;
+          for(const tax of ['cgst','sgst','igst']){
+            if(hasValue(node[tax])){
+              return true;
+            }
+          }
+        }
+        const taxRec = data.recovery?.tax || {};
+        for(const tax of ['cgst','sgst','igst']){
+          const bucket = taxRec[tax];
+          if(!bucket) continue;
+          if(hasValue(bucket.itc) || hasValue(bucket.cash)){
+            return true;
+          }
+        }
+        for(const cat of ['interest','penalty','late']){
+          const node = data.recovery?.[cat];
+          if(!node) continue;
+          for(const tax of ['cgst','sgst','igst']){
+            if(hasValue(node[tax])){
+              return true;
+            }
+          }
+        }
+        return false;
+      }
+      const revContainer = card.querySelector('[data-role="minor-rev"]');
+      if(!revContainer) return false;
+      const selectors = ['.rev-tax','.rev-int','.rev-pen','.rev-late','.rev-paid'];
+      return selectors.some(sel => hasValue(revContainer.querySelector(sel)?.value));
+    }
+
+    function formatOutstandingList(keys){
+      if(!keys.length) return '';
+      if(keys.length === 1) return PREFLIGHT_LABELS[keys[0]] || keys[0];
+      const initial = keys.slice(0, -1).map(key => PREFLIGHT_LABELS[key] || key);
+      const last = PREFLIGHT_LABELS[keys[keys.length - 1]] || keys[keys.length - 1];
+      return `${initial.join(', ')} and ${last}`;
+    }
+
+    function updatePreflightChecklist(){
+      const statusEl = $('preflightStatus');
+      const container = document.getElementById('paras-container');
+      const cards = container ? Array.from(container.children).filter(node => node.classList && node.classList.contains('para-card')) : [];
+      let gistMissing = 0;
+      let revenueMissing = 0;
+      let revenuePresent = 0;
+      cards.forEach(card => {
+        if(!cardHasGistContent(card)) gistMissing++;
+        if(cardHasRevenueContent(card)) revenuePresent++;
+        else revenueMissing++;
+      });
+      const requiredComplete = REQUIRED_FIELDS.every(({ id }) => {
+        const field = $(id);
+        return field && String(field.value || '').trim();
+      });
+      const auditComplete = auditDates.length > 0;
+      const hasParas = cards.length > 0;
+      const gistState = !hasParas ? 'pending' : (gistMissing === 0 ? 'complete' : 'attention');
+      const revenueState = !hasParas ? 'pending' : (revenueMissing === 0 && revenuePresent > 0 ? 'complete' : 'attention');
+      const states = {
+        unit: { state: requiredComplete ? 'complete' : 'pending', detail: requiredComplete ? '' : 'Fill every Part-I field except the optional A.R. number.' },
+        audit: { state: auditComplete ? 'complete' : 'pending', detail: auditComplete ? '' : 'Add at least one audit visit date.' },
+        paras: { state: hasParas ? 'complete' : 'pending', detail: hasParas ? '' : 'Add a major or minor para to continue.' },
+        gist: { state: gistState, detail: gistMissing > 0 ? `${gistMissing} para${gistMissing === 1 ? '' : 's'} still need gist text.` : '' },
+        revenue: { state: revenueState, detail: revenueMissing > 0 ? `${revenueMissing} para${revenueMissing === 1 ? '' : 's'} missing revenue figures will show ₹0 in exports.` : (revenueState === 'complete' ? 'All detection and recovery totals captured.' : '') }
+      };
+      Object.entries(states).forEach(([key, { state, detail }]) => setPreflightItemState(key, state, detail));
+      const blockingIncomplete = PRECHECK_BLOCKERS.filter(key => states[key].state !== 'complete');
+      preflightSnapshot = {
+        blockers: blockingIncomplete.length,
+        revenueMissing,
+        gistMissing,
+        cardCount: cards.length
+      };
+      if(statusEl){
+        if(blockingIncomplete.length === 0){
+          statusEl.dataset.state = 'ready';
+          statusEl.textContent = 'Ready to generate – all critical checks passed.';
+        }else{
+          const completed = PRECHECK_BLOCKERS.length - blockingIncomplete.length;
+          statusEl.dataset.state = 'blocked';
+          const outstanding = formatOutstandingList(blockingIncomplete);
+          statusEl.textContent = `${completed} of ${PRECHECK_BLOCKERS.length} critical items complete – ${outstanding} pending.`;
+        }
+      }
+      renderAutosaveInfo();
+    }
+
     function validateFormBeforeGenerate(){
       clearFieldHighlights();
       const errors = [];
       const invalidNodes = [];
-      const requiredFields = [
-        { id: 'f_name', label: 'Name of Unit' },
-        { id: 'f_gstin', label: 'Registration Number' },
-        { id: 'f_division', label: 'Commissionerate/Division/Range' },
-        { id: 'f_period', label: 'Period Covered' },
-        { id: 'f_ar', label: 'A.R. Number' }
-      ];
-      requiredFields.forEach(({ id, label }) => {
+      REQUIRED_FIELDS.forEach(({ id, label }) => {
         const field = $(id);
         if(!field) return;
         if(!String(field.value || '').trim()){
@@ -860,11 +1067,16 @@
       if(!container) return;
       const toast = document.createElement('div');
       toast.className = `toast ${type||''}`.trim();
+      toast.setAttribute('role', type === 'error' ? 'alert' : 'status');
+      toast.setAttribute('aria-live', type === 'error' ? 'assertive' : 'polite');
+      toast.tabIndex = -1;
       const text = document.createElement('div');
       text.textContent = message;
       toast.appendChild(text);
+      let timer = null;
       const dismiss = ()=>{
         toast.classList.remove('show');
+        if(timer){ clearTimeout(timer); timer = null; }
         setTimeout(()=>{ if(toast.parentNode) toast.parentNode.removeChild(toast); }, 300);
       };
       if(opts && opts.actionLabel && typeof opts.onAction === 'function'){
@@ -874,10 +1086,22 @@
         btn.addEventListener('click', ()=>{ opts.onAction(); dismiss(); });
         toast.appendChild(btn);
       }
+      const closeBtn = document.createElement('button');
+      closeBtn.type = 'button';
+      closeBtn.className = 'toast-dismiss';
+      closeBtn.textContent = 'Dismiss';
+      closeBtn.addEventListener('click', dismiss);
+      toast.appendChild(closeBtn);
+      toast.addEventListener('keydown', (event)=>{
+        if(event.key === 'Escape'){ event.preventDefault(); dismiss(); }
+      });
       container.appendChild(toast);
       requestAnimationFrame(()=> toast.classList.add('show'));
       const duration = typeof opts.duration === 'number' ? opts.duration : 5000;
-      if(duration > 0){ setTimeout(dismiss, duration); }
+      if(duration > 0){ timer = setTimeout(dismiss, duration); }
+      if((opts && opts.focus) || type === 'error'){
+        setTimeout(()=>{ try{ toast.focus({ preventScroll: true }); }catch(_){} }, 60);
+      }
     }
     function downloadLastOutput(){
       if(!lastGeneratedBlob){
@@ -941,6 +1165,7 @@
       $('f_audit_dates').value = auditDates.join(', ');
       const err = $('auditDateError');
       if(err){ err.textContent = ''; err.style.display = 'none'; }
+      updatePreflightChecklist();
     }
     function wireAuditDates(){
       const addBtn = $('addAuditDateBtn');
@@ -1409,6 +1634,12 @@
     $('addMinorRow').onclick = ()=> addRow({}, { minor:true });
     $('clearRows').onclick = ()=> { parasContainer.innerHTML=''; renumberParas(); };
 
+    REQUIRED_FIELDS.forEach(({ id }) => {
+      const field = $(id);
+      if(!field) return;
+      ['input','change','blur'].forEach(evt => field.addEventListener(evt, () => updatePreflightChecklist()));
+    });
+
     function renumberParas(){
       let i = 1;
       for(const card of Array.from(parasContainer.children)){
@@ -1419,6 +1650,7 @@
       applyGroupVisibility();
       updatePart1TotalsFromParas();
       updateDashboard();
+      updatePreflightChecklist();
     }
 
     function applyGroupVisibility(){
@@ -1614,6 +1846,7 @@
       const detDisplay = detectionHas ? formatCurrencyValue(detectionTotal) : '—';
       const recDisplay = recoveryHas ? formatCurrencyValue(recoveryCash + recoveryItc) : '—';
       summaryEl.innerHTML = `<span class="pill">Det ${detDisplay}</span><span class="pill">Rec ${recDisplay}</span><span class="pill ${statusClass}">${statusLabel}</span>`;
+      updatePreflightChecklist();
     }
     function refreshAllParaSummaries(){
       document.querySelectorAll('.para-card').forEach(card => updateParaSummary(card));
@@ -2351,12 +2584,21 @@
       const info = $('autosaveInfo');
       const restoreBtn = $('restoreAutosave');
       if(info){
+        let text;
         if(autosaves.length){
           const ts = autosaves[0].ts;
-          info.textContent = `Last autosave: ${formatTimestamp(ts)} (${formatRelative(ts)})`;
+          text = `Last autosave: ${formatTimestamp(ts)} (${formatRelative(ts)})`;
         }else{
-          info.textContent = 'No autosaves yet';
+          text = 'No autosaves yet';
         }
+        if(preflightSnapshot.cardCount > 0){
+          if(preflightSnapshot.revenueMissing > 0){
+            text += ` • ${preflightSnapshot.revenueMissing} para${preflightSnapshot.revenueMissing === 1 ? '' : 's'} missing revenue totals.`;
+          }else{
+            text += ' • Revenue figures captured for all paras.';
+          }
+        }
+        info.textContent = text;
       }
       if(restoreBtn){ restoreBtn.disabled = autosaves.length === 0; }
     }
@@ -3179,7 +3421,6 @@
       }
       $('log').textContent='';
       setStatus('Generating…');
-      genBtn.disabled = true;
       showOverlay('Generating DAR…');
       if(partTotalsTimer){ clearTimeout(partTotalsTimer); partTotalsTimer = null; }
       try{ updatePart1TotalsFromParas(); }catch(_){}
@@ -3217,7 +3458,6 @@
       }
       finally{
         hideOverlay();
-        genBtn.disabled = false;
       }
     });
 
@@ -3286,6 +3526,7 @@
       reader.readAsText(file);
     });
 
+    updatePreflightChecklist();
     initAutosave();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- mark every Part-I field except the A.R. number as required and update the checklist messaging accordingly
- keep the Generate DAR button enabled while still surfacing pre-flight status updates for missing data
- refresh README guidance to note the stricter Part-I requirements and the always-available Generate action

## Testing
- browser_container.run_playwright_script

------
https://chatgpt.com/codex/tasks/task_e_68d8ef334b4c832c89a55e1fa1ec315a