### PR TITLE
Remove pasted CSS from gist editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -708,12 +708,15 @@
       let output = String(input);
       output = output.replace(/<!--[\s\S]*?-->/g, '');
       output = output.replace(/\/\*[\s\S]*?\*\//g, '');
+      output = output.replace(/<(style|script|title|head|xml)[^>]*>[\s\S]*?<\/\1>/gi, '');
+      output = output.replace(/<(meta|link|base)[^>]*>/gi, '');
       output = output.replace(/@font-face\s*\{[\s\S]*?\}/gi, '');
       output = output.replace(/mso-[a-z-]+:[^;"']*;?/gi, '');
       return output;
     }
 
     const ALLOWED_RICH_TAGS = new Set(['p','br','strong','em','u','b','i','a','ul','ol','li','table','thead','tbody','tr','th','td','span','div','sup','sub']);
+    const BLOCKED_RICH_TAGS = new Set(['style','script','meta','link','title','head','base','xml']);
     const ALLOWED_RICH_ATTRS = {
       a: ['href'],
       td: ['colspan','rowspan'],
@@ -755,6 +758,9 @@
           return null;
         }
         const tag = node.tagName.toLowerCase();
+        if(BLOCKED_RICH_TAGS.has(tag)){
+          return null;
+        }
         if(!ALLOWED_RICH_TAGS.has(tag)){
           const fragment = document.createDocumentFragment();
           cleanChildren(node, fragment);


### PR DESCRIPTION
## Summary
- strip out Word-generated style and metadata elements before sanitizing pasted gist content
- drop blocked elements entirely during sanitization so their CSS text is never appended

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68db97a65b60832cb9563e0ca1e4d83e